### PR TITLE
Add null checks and improve Javadoc in Strops

### DIFF
--- a/app/src/main/java/strings/Strops.java
+++ b/app/src/main/java/strings/Strops.java
@@ -2,12 +2,16 @@ package strings;
 
 public class Strops {
   /**
-   * Reverses a string
+   * Reverses a string.
    *
-   * @param str The string to reverse.
+   * @param str The string to reverse. Must not be null.
    * @return The reversed string.
+   * @throws IllegalArgumentException if {@code str} is null.
    */
   public String reverse(String str) {
+    if (str == null) {
+      throw new IllegalArgumentException("Input string must not be null");
+    }
     StringBuilder reversed = new StringBuilder();
     for (int i = str.length() - 1; i >= 0; i--) {
       reversed.append(str.charAt(i));
@@ -16,12 +20,16 @@ public class Strops {
   }
 
   /**
-   * Checks if a string is a palindrome
+   * Checks if a string is a palindrome.
    *
-   * @param str The string to check.
-   * @return True if the string is a palindrome, false otherwise.
+   * @param str The string to check. Must not be null.
+   * @return True if the string is a palindrome, false otherwise. Returns false for empty strings.
+   * @throws IllegalArgumentException if {@code str} is null.
    */
   public boolean isPalindrome(String str) {
+    if (str == null) {
+      throw new IllegalArgumentException("Input string must not be null");
+    }
     if (str.length() == 0) {
       return false;
     }


### PR DESCRIPTION
## Summary
Harden `Strops` against null inputs and clarify its Javadoc so callers understand the contract.

## Changes
- Throw `IllegalArgumentException` from `reverse` and `isPalindrome` when input is null
- Update Javadoc to document the null contract and the empty-string behaviour of `isPalindrome`
- Minor punctuation fixes in method descriptions

## Notes
This introduces a behavioural change: previously a null argument would surface as a `NullPointerException`. Callers now receive an `IllegalArgumentException` with a descriptive message.

---

changeset_id: 488cfdbd-a504-4565-b43e-b5fd717b3bb4

### Trigger Artemis Fix Agent to iterate on comments left on your PR

1. **Wait until your reviewers are done** leaving comments on the PR.
2. **Tag `@artemis-fix-agent` in a new comment** — this will be your trigger comment. Optionally, add further instructions you want Artemis to act on.

**Example trigger comment:**
```
@artemis-fix-agent address all the review feedback above.
```

Artemis will pick up **all existing PR comments** automatically. Note that each time you tag `@artemis-fix-agent`, a separate, parallel fix attempt will be kicked off, so only tag Artemis once you're ready to start.